### PR TITLE
Allow 'b' shorthand for the 'build' subparser.

### DIFF
--- a/debspawn/cli.py
+++ b/debspawn/cli.py
@@ -284,7 +284,7 @@ def create_parser(formatter_class=None):
     sp.set_defaults(func=command_update)
 
     # 'build' command
-    sp = subparsers.add_parser('build', help='Build a package in an isolated environment', formatter_class=formatter_class)
+    sp = subparsers.add_parser('build', help='Build a package in an isolated environment', formatter_class=formatter_class, aliases=['b'])
     add_container_select_arguments(sp)
     sp.add_argument('-s', '--sign', action='store_true', dest='sign',
                     help='Sign the resulting package.')


### PR DESCRIPTION
https://stackoverflow.com/questions/13609118/make-pythons-argparse-accept-single-character-abbreviations-for-subparsers