### PR TITLE
Travis-ci: added ppc64le support along with amd64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@
 language: python
 dist: bionic
 sudo: required
+arch:
+  - amd64
+  - ppc64le
 
 addons:
   apt:


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch . The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjay-cpu/debspawn/builds/185833777 . I believe it is ready for the final review and merge.
Please have a look on it and if everything looks fine for you then please approve it for merge.

Thanks !!