### PR TITLE
Document configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,16 @@ $ debspawn build --arch=i386 cosmic ./hello_2.10-1.dsc
 
 Build results are by default returned in `/var/lib/debspawn/results/`
 
+If you need to inject other local packages as build dependencies, place `deb` files in `/var/lib/debspawn/injected-pkgs` (or other location set in the config file).
+
 ### Building a package - with git-buildpackage
 
 You can use a command like this to build your project with gbp and Debspawn:
 ```bash
 $ gbp buildpackage --git-builder='debspawn build sid --sign'
 ```
+
+You might also want to add `--results-dir ..` to the debspawn arguments to get the resulting artifacts in the directory to which the package repository was originally exported.
 
 ### Manual interactive-shell action
 
@@ -129,6 +133,18 @@ $ debspawn delete --arch=i386 cosmic
 This is achieved with the `debspawn run` command and is a bit more involved. Refer to the manual page
 and help output for more information.
 
+### Global configuration
+
+Debspawn will read a global configuration file from `/etc/debspawn/config.json`, or a configuration file in a location specified by the `--config` flag. If a config file is specified on the command line, the global file is ignored rather than merged.
+
+The config is a JSON file containing any of the following (all optional) keys:
+
+* `OSRootsDir`: directory for os images (`/var/lib/debspawn/containers/`)
+* `ResultsDir`: directory for build artifacts (`/var/lib/debspawn/results/`)
+* `APTCacheDir`: directory for debspawn's own package cache (`/var/lib/debspawn/aptcache/`)
+* `InjectedPkgsDir`: packages placed in this directory will be available as dependencies for builds (`/var/lib/debspawn/injected-pkgs/`)
+* `TempDir`: temporary directory used for running containers (`/var/tmp/debspawn/`)
+* `AllowUnsafePermissions`: allow usage of risker container permissions, such as binding the host `/dev` and `/proc` into the container (`false`)
 
 ## FAQ
 

--- a/docs/debspawn.1.xml
+++ b/docs/debspawn.1.xml
@@ -157,6 +157,77 @@
 	</refsect1>
 
 	<refsect1>
+		<title>Configuration</title>
+
+		<para>
+			Configuration is read from an optional JSON file, located at /etc/debspawn/global.json or a location specified with <option>--config</option>. Specifying a config file on the command line overrides the global file, rather than merges the contents.
+		</para>
+
+		<para>
+			The following keys are understood. All are optional:
+		</para>
+
+		<variablelist>
+
+			<varlistentry>
+				<term><option>OSRootsDir</option></term>
+				<listitem>
+					<para>
+						Location for stored container images.
+					</para>
+				</listitem>
+			</varlistentry>
+
+			<varlistentry>
+				<term><option>ResultsDir</option></term>
+				<listitem>
+					<para>
+						Location where build artifacts will be placed.
+					</para>
+				</listitem>
+			</varlistentry>
+
+			<varlistentry>
+				<term><option>APTCacheDir</option></term>
+				<listitem>
+					<para>
+						Location for debspawn's package cache.
+					</para>
+				</listitem>
+			</varlistentry>
+
+			<varlistentry>
+				<term><option>InjectedPkgsDir</option></term>
+				<listitem>
+					<para>
+						Package files in this directory will be available to satisfy build dependencies.
+					</para>
+				</listitem>
+			</varlistentry>
+
+			<varlistentry>
+				<term><option>TempDir</option></term>
+				<listitem>
+					<para>
+						Temporary directory for running containers.
+					</para>
+				</listitem>
+			</varlistentry>
+
+			<varlistentry>
+				<term><option>AllowUnsafePermissions</option></term>
+				<listitem>
+					<para>
+						Whether unsafe options can be used when creating the container, such as binding the host /dev and /proc.
+					</para>
+				</listitem>
+			</varlistentry>
+
+		</variablelist>
+
+	</refsect1>
+
+	<refsect1>
 		<title>See Also</title>
 		<para>dpkg-buildpackage(1), systemd-nspawn(1), sbuild(1).</para>
 	</refsect1>


### PR DESCRIPTION
Adds a section to both `debspawn.1` and `README.md` describing the location and precedence of the configuration file, and the (as far as I can tell) currently supported options.